### PR TITLE
Allow Single Optional Deselect

### DIFF
--- a/chosen/__init__.py
+++ b/chosen/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (0, 1)
+VERSION = (0, 1)

--- a/chosen/static/js/chosen.jquery_ready.js
+++ b/chosen/static/js/chosen.jquery_ready.js
@@ -17,8 +17,13 @@
                 }).css('overflow', 'visible');
             }
 
+            options = {}
+            if ($select.attr('data-optional')) {
+                options['allow_single_deselect'] = true;
+            }
+
             // Initialize Chosen
-            $select.chosen();
+            $select.chosen(options);
         });
     });
 })((typeof window.django != 'undefined') ? django.jQuery : jQuery);

--- a/chosen/widgets.py
+++ b/chosen/widgets.py
@@ -20,6 +20,11 @@ class ChosenWidgetMixin(object):
 
         super(ChosenWidgetMixin, self).__init__(attrs, *args, **kwargs)
 
+    def render(self, *args, **kwargs):
+        if not self.is_required:
+            self.attrs.update({'data-optional': True})
+        return super(ChosenWidgetMixin, self).render(*args, **kwargs)
+
     def add_to_css_class(self, classes, new_class):
         new_classes = classes
         try:

--- a/chosen/widgets.py
+++ b/chosen/widgets.py
@@ -17,7 +17,6 @@ class ChosenWidgetMixin(object):
         attrs['data-placeholder'] = kwargs.pop('overlay', None)
         attrs['class'] = "class" in attrs and self.add_to_css_class(
             attrs['class'], 'chzn-select') or "chzn-select"
-
         super(ChosenWidgetMixin, self).__init__(attrs, *args, **kwargs)
 
     def render(self, *args, **kwargs):
@@ -50,4 +49,3 @@ class ChosenGroupSelect(ChosenSelect):
     def __init__(self, attrs={}, *args, **kwargs):
         super(ChosenGroupSelect, self).__init__(attrs, *args, **kwargs)
         attrs["class"] = "chzn-single chzn-single-with-drop"
-


### PR DESCRIPTION
For fields that are optional, users need a way to deselect a value completely.  Currently, once something is set with chosen, there's no going back.

By using the `data-optional` attribute, and reading it into the javascript, we can pass the proper Chosen setting - `allow_single_deselect` - to allow users to deselect the value.
